### PR TITLE
use Minecraft OSGi API dependency from Central

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ language: java
 jdk:
   - openjdk8
 
-before_install:
-  - git clone --recursive https://github.com/vorburger/ch.vorburger.minecraft.osgi/
-  - cd ch.vorburger.minecraft.osgi/ch.vorburger.osgi.gradle && ./gradlew install
-  - cd .. && ./gradlew install
-  - cd ..
-
 cache:
   directories:
   - $HOME/.gradle

--- a/storeys/build.gradle
+++ b/storeys/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation 'org.osgi:org.osgi.core:6.0.0'
-    implementation 'ch.vorburger.minecraft:ch.vorburger.minecraft.osgi.api:1.0.0-SNAPSHOT'
+    implementation 'ch.vorburger.minecraft.osgi:api:1.0.0'
 }
 
 shadowJar {
@@ -12,7 +12,7 @@ shadowJar {
     // http://imperceptiblethoughts.com/shadow/#filtering_dependencies
     // NB "not being able to filter entire transitive dependency graphs"
     // so instead of using exclude dependency we just do explicit include:
-    include(dependency('ch.vorburger.minecraft:ch.vorburger.minecraft.osgi.api'))
+    include(dependency('ch.vorburger.minecraft.osgi:api'))
   }
 }
 

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(':scratch')
 
     implementation 'org.osgi:org.osgi.core:6.0.0'
-    implementation 'ch.vorburger.minecraft:ch.vorburger.minecraft.osgi.api:1.0.0-SNAPSHOT'
+    implementation 'ch.vorburger.minecraft.osgi:api:1.0.0'
 
     compile "io.vertx:vertx-core:$vertxVersion"
     compile "io.vertx:vertx-web:$vertxVersion"
@@ -67,7 +67,7 @@ shadowJar {
     include(dependency("com.fasterxml.jackson.core:jackson-core"))
     include(dependency("com.fasterxml.jackson.core:jackson-databind"))
     include(dependency("com.fasterxml.jackson.core:jackson-annotations"))
-    include(dependency('ch.vorburger.minecraft:ch.vorburger.minecraft.osgi.api'))
+    include(dependency("ch.vorburger.minecraft.osgi:api"))
   }
 }
 


### PR DESCRIPTION
I have just finally deployed this to Maven central,
so we (and builds, incl. S2I in OpenShift..) do not
have to locally build and install this project anymore:
https://github.com/vorburger/ch.vorburger.minecraft.osgi

This therefore also removes building that in Travis CI.