### PR TITLE
extend SeleniumTest to cover getItemHeld

### DIFF
--- a/scratch/src/index.html
+++ b/scratch/src/index.html
@@ -16,6 +16,8 @@
 <body>
   <button id="sendTitle" onclick="ext.scratchMinecraftExtension.sendTitle('hello, world', ext.callback(this.id))">Send Title</button>
   <button id="narrate" onclick="ext.scratchMinecraftExtension.narrate('joe', 'hi', ext.callback(this.id))">Narrate</button>
+
+  <button id="tester" onclick="tester.test()">Run new tester</button>
 </body>
 
 </html>

--- a/web/src/test/java/ch/vorburger/minecraft/storeys/web/test/TestMinecraft.java
+++ b/web/src/test/java/ch/vorburger/minecraft/storeys/web/test/TestMinecraft.java
@@ -64,7 +64,7 @@ public class TestMinecraft implements Minecraft {
 
     @Override
     public void getItemHeld(String code, HandType hand, Handler<AsyncResult<ItemType>> handler) {
-        handler.handle(Future.succeededFuture(itemsHeld.get(hand)));
+        handler.handle(Future.succeededFuture(itemsHeld.getOrDefault(hand, ItemType.Nothing)));
     }
 
 }


### PR DESCRIPTION
but run that new client side, and test new API not Scratch Binding

see https://github.com/vorburger/minecraft-storeys-maker/issues/85

The quick hack fix in test.ts to await EB ready will be replaced
by edewit who will provide something equivalent directly
in the Minecraft API wrapper class.