### PR TITLE
add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,8 @@
 .git
 build
-gradle
+# gradle
 
-storeys
-scratch
+# storeys
+# scratch
 
 bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:8
+# TODO FROM openjdk:11 AS builder
+# TODO FROM registry.access.redhat.com/ubi8/ubi
+# TODO RUN yum install java-11-openjdk-devel
+COPY . .
+# TODO RUN git reset --hard; git clean -d -f -x
+RUN ./gradlew clean build
+
+# FROM gcr.io/distroless/java:11
+# COPY --from=builder web/build/libs/ .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-FROM openjdk:8
-# TODO FROM openjdk:11 AS builder
-# TODO FROM registry.access.redhat.com/ubi8/ubi
-# TODO RUN yum install java-11-openjdk-devel
-COPY . .
-# TODO RUN git reset --hard; git clean -d -f -x
-RUN ./gradlew clean build
+FROM openjdk:8-jdk as build
 
-# FROM gcr.io/distroless/java:11
-# COPY --from=builder web/build/libs/ .
+RUN apt-get update
+COPY . /project
+WORKDIR /project
+RUN ./gradlew build -x test
+
+FROM itzg/minecraft-server
+COPY --from=build /project/web/build/libs/*-all.jar /data/mods/
+
+ENV EULA=TRUE
+ENV TYPE=SPONGEVANILLA
+EXPOSE 25565 25575
+ENTRYPOINT [ "/start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ COPY --from=build /project/web/build/libs/*-all.jar /data/mods/
 
 ENV EULA=TRUE
 ENV TYPE=SPONGEVANILLA
-EXPOSE 25565 25575
+EXPOSE 25565 25575 7070 8080
 ENTRYPOINT [ "/start" ]

--- a/README.md
+++ b/README.md
@@ -75,10 +75,19 @@ You can obviously mix the order and repeat titles, comments, chats, narrations, 
 
 ### Locally in a container
 
-With S2I, and with git reset and clean due to #28 and #71:
+#### Dockerfile
 
-    cd ../s2i/java/images/jboss
-    docker build . -t fabric8/s2i-java
+    cd ../s2i-minecraft-server
+    docker build -t minecraft-server .
+
+    cd ../minecraft-storeys-maker
+    docker build -t minecraft-storeys-maker .
+
+    docker run --rm -p 25565:25565 -p 8080:8080 -p 7070:7070 minecraft-storeys-maker
+
+#### S2I
+
+With S2I, and with git reset and clean due to #28 and #71:
 
     cd ../s2i-minecraft-server
     s2i build --copy . fabric8/s2i-java s2i-minecraft-server


### PR DESCRIPTION
@edewit a starting point.. this won't actually work yet - we'd first need something similar over in https://github.com/OASIS-learn-study/s2i-minecraft-server, or perhaps create a copy of the project. Or, actually, easiest probably just to put that `server.properties` and `ops.json` into this project... either way, that's the smallest problem - for some reason, this won't even build, inside a Container?! Not sure what to make of this error, but IMHO the simplest would be to not waste time investigating this, but try to upgrade Gradle? So this would need #164, and your help... some day.

```
[vorburger@toby minecraft-storeys-maker]$ docker build .
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
STEP 1: FROM openjdk:8
STEP 2: COPY . .
056c09c412c61631a70d31e65331bef63a213057005f981ace9a073104137524
STEP 3: RUN ./gradlew clean build
Error: Could not find or load main class org.gradle.wrapper.GradleWrapperMain
Error: error building at STEP "RUN ./gradlew clean build": error while running runtime: exit status 1
```