### PR TITLE
Make scratch3 the default.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ coverage/
 *d.ts
 
 web/.vertx/file-cache-*
+.vertx/
 
 .vscode/
 .history/

--- a/scratch3/build.gradle
+++ b/scratch3/build.gradle
@@ -57,7 +57,7 @@ task npmBuild {
 assemble.dependsOn(npmBuild)
 
 jar {
-  into 'static/scratch3', {
+  into 'static', {
     from "$buildDir/scratch-gui/build"
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
-include 'engine', 'api', 'storeys', 'web', 'scratch' // , 'scratch3'
+include 'engine', 'api', 'storeys', 'web', 'scratch3'
 
 rootProject.name = 'minecraft-storeys-maker'

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -7,8 +7,8 @@ plugins {
 dependencies {
     implementation project(':api')
     implementation project(':storeys')
-    implementation project(':scratch')
-    // implementation project(':scratch3')
+    //implementation project(':scratch')
+    implementation project(':scratch3')
 
     implementation 'org.osgi:org.osgi.core:6.0.0'
     implementation 'ch.vorburger.minecraft.osgi:api:1.0.0'
@@ -16,6 +16,14 @@ dependencies {
 
     testCompile "org.seleniumhq.selenium:selenium-java:3.141.59"
     testCompile 'io.github.bonigarcia:webdrivermanager:3.8.1'
+}
+
+task runWithJavaExec(type: JavaExec) {
+  group = "Execution"
+  description = "Run the main class with JavaExecTask"
+  classpath = sourceSets.test.runtimeClasspath
+  main = "ch.vorburger.minecraft.storeys.web.SeleniumTest"
+  standardInput = System.in
 }
 
 shadowJar {
@@ -40,8 +48,8 @@ shadowJar {
     // so instead of using exclude dependency we just do explicit include:
     include(project(':api'))
     include(project(':storeys'))
-    include(project(':scratch'))
-    // include(project(':scratch3'))
+//    include(project(':scratch'))
+    include(project(':scratch3'))
     include(dependency("io.vertx:vertx-core"))
     include(dependency("io.vertx:vertx-web"))
     include(dependency("io.vertx:vertx-auth-common"))

--- a/web/src/main/java/ch/vorburger/minecraft/storeys/web/LoginCommand.java
+++ b/web/src/main/java/ch/vorburger/minecraft/storeys/web/LoginCommand.java
@@ -44,10 +44,7 @@ import org.spongepowered.api.text.format.TextColors;
  */
 public class LoginCommand implements Command {
 
-    private static final String SCRATCHX_URL_PREFIX = "http://scratchx.org/?url=%s&code=%s&eventBusURL=%s";
-    private String scratchX_JSExtensionURL = "http://localhost:7070/minecraft.scratchx.js";
-
-    private String scratch3URL = "http://localhost:8601/?";
+    private String scratch3URL = "http://localhost:7070/index.html?";
 
     private String eventBusURL = "http://localhost:8080";
     private String encodedEventBusURL;
@@ -56,7 +53,6 @@ public class LoginCommand implements Command {
 
     public LoginCommand(TokenProvider tokenProvider) {
         this.tokenProvider = tokenProvider;
-        scratchX_JSExtensionURL = getSystemPropertyEnvVarOrDefault("storeys_jsURL", scratchX_JSExtensionURL);
         scratch3URL = getSystemPropertyEnvVarOrDefault("storeys_scratchURL", scratch3URL);
         eventBusURL = getSystemPropertyEnvVarOrDefault("storeys_eventBusURL", eventBusURL);
         try {
@@ -99,15 +95,7 @@ public class LoginCommand implements Command {
                 Player player = (Player)src;
 
                 String code = tokenProvider.getCode(player);
-
-                String url;
-                if (args.hasAny("b")) {
-                    url = String.format(scratch3URL + "code=%s&eventBusURL=%s", code, encodedEventBusURL);
-                } else {
-                    url = String.format(SCRATCHX_URL_PREFIX,
-                        URLEncoder.encode(scratchX_JSExtensionURL, StandardCharsets.UTF_8.name()), code,
-                        encodedEventBusURL);
-                }
+                String url = String.format(scratch3URL + "code=%s&eventBusURL=%s", code, encodedEventBusURL);
 
                 src.sendMessage(Text.builder("Click here to open Scratch and MAKE actions").onClick(
                         TextActions.openUrl(new URL(url))).color(TextColors.GOLD).build());

--- a/web/src/main/java/ch/vorburger/minecraft/storeys/web/NodeStarter.java
+++ b/web/src/main/java/ch/vorburger/minecraft/storeys/web/NodeStarter.java
@@ -20,7 +20,6 @@ package ch.vorburger.minecraft.storeys.web;
 
 import com.github.eirslett.maven.plugins.frontend.lib.*;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -40,8 +39,8 @@ class NodeStarter {
     }
 
     void start() {
-        FrontendPluginFactory frontendPluginFactory = new FrontendPluginFactory(configDir.toFile(), new File("/tmp"));
         try {
+            FrontendPluginFactory frontendPluginFactory = new FrontendPluginFactory(configDir.toFile(), Files.createTempDirectory("stories").toFile());
             Path packageJson = configDir.resolve("package.json");
             if (Files.notExists(packageJson)) {
                 Files.copy(getClass().getResourceAsStream("/package.json"), packageJson);

--- a/web/src/main/java/ch/vorburger/minecraft/storeys/web/StaticWebServerVerticle.java
+++ b/web/src/main/java/ch/vorburger/minecraft/storeys/web/StaticWebServerVerticle.java
@@ -43,7 +43,7 @@ public class StaticWebServerVerticle extends AbstractHttpServerVerticle {
     @Inject
     public StaticWebServerVerticle(@Named("web-http-port") int httpPort) {
         super(httpPort);
-        this.webRoot = "static"; // ~= ../scratch/dist/*.js
+        this.webRoot = "static"; // ~= ../scratch-gui/build/*
     }
 
     public StaticWebServerVerticle(int httpPort, File webRoot) {


### PR DESCRIPTION
Instead of redirecting users to the scratch site when they type `/make` we redirect them to our version of the scratch3 UI.
This PR updates the build to clone and build the forked scratch3 repo that adds our plugin to the scratch3 UI